### PR TITLE
Small readme typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ a Next.js setup to use as reference.
 
 ```tsx
 import { render } from "react-dom";
-import { CacheProvider } from "@emotion/react";
-import { getCache } from "tss-react/cache";
+import { CacheProvider } from "@emotion/react";
+import { getCache } from "tss-react/cache";
 
 render(
     <CacheProvider value={getCache()}>
         <Root />
-    </StyledEngineProvider>,
+    </CacheProvider>,
     document.getElementById("root"),
 );
 ```
@@ -153,7 +153,7 @@ import { makeStyles } from "../../../../../../makeStyles";
 ```
 
 You can put [`"baseUrl": "src"`](https://github.com/InseeFrLab/onyxia-web/blob/ae02b05cd7b17d74fb6a8cbc4c7b1c6f569dfa41/tsconfig.json#L3) in
-your `tsconfig.json` and import things [relative yo your `src/` directory](https://github.com/garronej/tss-react/blob/314aaab87198e7fd3523e34300288495f3242800/src/test/spa/src/index.tsx#L2-L3).
+your `tsconfig.json` and import things [relative to your `src/` directory](https://github.com/garronej/tss-react/blob/314aaab87198e7fd3523e34300288495f3242800/src/test/spa/src/index.tsx#L2-L3).
 
 <p align="center">
     <i>Try it now:</i><br>


### PR DESCRIPTION
Fixes for a couple small typos I noticed in the readme file.
I'd also recommend publishing a new npm package, the latest one (0.6.0-beta.1) doesn't have the getCache function