### PR TITLE
Make Params type Injectable with useStyles

### DIFF
--- a/src/makeStyles.tsx
+++ b/src/makeStyles.tsx
@@ -23,7 +23,7 @@ export function createMakeStyles<Theme>(params: { useTheme: () => Theme }) {
 
     /** returns useStyle. */
     function makeStyles<
-        Params = void,
+        ParamsType = void,
         RuleNameSubsetReferencableInNestedSelectors extends string = never,
     >(params?: { name?: string | Record<string, unknown> }) {
         const { name: nameOrWrappedName } = params ?? {};
@@ -33,7 +33,7 @@ export function createMakeStyles<Theme>(params: { useTheme: () => Theme }) {
                 ? nameOrWrappedName
                 : Object.keys(nameOrWrappedName)[0];
 
-        return function <RuleName extends string>(
+        return function <Params = ParamsType, RuleName extends string = string>(
             cssObjectByRuleNameOrGetCssObjectByRuleName:
                 | ((
                       theme: Theme,


### PR DESCRIPTION
Hi @garronej !
Thanks for your quick response again!
I totally agree with you that I lose type safety on that approach anyway I've got another workaround that you may like.
By making it possible to inject Params type in useStyles will make it.
Check the new changes.
https://codesandbox.io/s/angry-ride-xmjso?file=/pages/index.tsx