### PR TITLE
Add support of merging classes in withStyles

### DIFF
--- a/src/mergeClasses.ts
+++ b/src/mergeClasses.ts
@@ -20,6 +20,12 @@ export function mergeClasses<T extends string>(
         ruleName =>
             (out[ruleName] = cx(classes[ruleName], classesOv[ruleName])),
     );
+    objectKeys(classesOv).forEach(ruleName => {
+        const value = classesOv[ruleName] as string | undefined;
+        if (!(ruleName in out) && value !== undefined) {
+            out[ruleName] = value;
+        }
+    });
 
     return out;
 }

--- a/src/withStyles.tsx
+++ b/src/withStyles.tsx
@@ -5,6 +5,7 @@ import type { ReactComponent } from "./tools/ReactComponent";
 import type { CSSObject } from "./types";
 import { createMakeStyles } from "./makeStyles";
 import { capitalize } from "./tools/capitalize";
+import { mergeClasses } from "./mergeClasses";
 
 export function createWithStyles<Theme>(params: { useTheme: () => Theme }) {
     const { useTheme } = params;
@@ -93,13 +94,17 @@ export function createWithStyles<Theme>(params: { useTheme: () => Theme }) {
         const Out = forwardRef<any, Props>(function (props, ref) {
             const { classes, cx } = useStyles(props);
 
-            const { className, ...rest } = props;
+            const { className, classes: propsClasses, ...rest } = props;
 
             return (
                 <Component_
                     ref={ref}
                     className={cx(classes.root, className)}
-                    {...(typeof Component === "string" ? {} : { classes })}
+                    {...(typeof Component === "string"
+                        ? {}
+                        : {
+                              classes: mergeClasses(classes, propsClasses, cx),
+                          })}
                     {...rest}
                 />
             );

--- a/src/withStyles_compat.tsx
+++ b/src/withStyles_compat.tsx
@@ -5,6 +5,7 @@ import type { ReactComponent } from "./tools/ReactComponent";
 import type { CSSObject } from "./types";
 import { createMakeStyles } from "./makeStyles";
 import { capitalize } from "./tools/capitalize";
+import { mergeClasses } from "./mergeClasses";
 
 export function createWithStyles<Theme>(params: { useTheme: () => Theme }) {
     const { useTheme } = params;
@@ -80,13 +81,17 @@ export function createWithStyles<Theme>(params: { useTheme: () => Theme }) {
         const Out = forwardRef<any, Props>(function (props, ref) {
             const { classes, cx } = useStyles(props);
 
-            const { className, ...rest } = props;
+            const { className, classes: propsClasses, ...rest } = props;
 
             return (
                 <Component_
                     ref={ref}
                     className={cx(classes.root, className)}
-                    {...(typeof Component === "string" ? {} : { classes })}
+                    {...(typeof Component === "string"
+                        ? {}
+                        : {
+                              classes: mergeClasses(classes, propsClasses, cx),
+                          })}
                     {...rest}
                 />
             );


### PR DESCRIPTION
Hello,

we just migrated to `tss-react` in MUIv4 based project and we found a small difference in how `withStyles` work in MUI and here.

The difference is in maybe a special case. Here's a small example:
```tsx
import InputBase from '@material-ui/core/InputBase';
import { withStyles } from 'common-ui/styles';

export const CustomInputBase = withStyles(
  InputBase,
  (theme) =>
    ({
      input: {
        backgroundColor: theme.palette.grey[50],
      },
    } as const)
);

const StyledInput = withStyles(CustomInputBase, () => ({
  input: {
     backgroundColor: 'red'
  },
}));
```

The problem is that `StyledInput` won't get `red` color as one would expect. The reason is that `withStyles` currently doesn't merge `classes` passed in `props` of the wrapping component.

I tried to add it by using `mergeClasses` function where I noticed another small issue. The problem is when `classes` doesn't contain all the keys; then the key present on `classesOv` would be missing in the output classes object.