### PR TITLE
Pass all classes to the component, not only root

### DIFF
--- a/src/withStyles.tsx
+++ b/src/withStyles.tsx
@@ -97,7 +97,7 @@ export function createWithStyles<Theme>(params: { useTheme: () => Theme }) {
             return (
                 <Component_
                     ref={ref}
-                    className={cx(classes.root, className)}
+                    className={cx(...Object.keys(classes), className)}
                     {...(typeof Component === "string" ? {} : { classes })}
                     {...rest}
                 />


### PR DESCRIPTION
Hi, I have a code below, and in this case, `minHeight:32` will be added to styles on the page but not used by the component.
I propose to pass all classes to component
What do you think?

```typescript
import {Tab} from '@mui/material';
import {withStyles} from 'tss-react/mui';

const StyledTab = withStyles(Tab, (theme: Theme, _params, classes) => ({
  root: {
    display: 'flex',
  },
  labelIcon: {
    minHeight: 32,
}));
```