### PR TITLE
Improve wrapping of component name with displayName

### DIFF
--- a/src/withStyles.tsx
+++ b/src/withStyles.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { forwardRef, createElement } from "react";
-import type { ReactHTML } from "react";
+import type { ReactHTML, FunctionComponent } from "react";
 import type { ReactComponent } from "./tools/ReactComponent";
 import type { CSSObject } from "./types";
 import { createMakeStyles } from "./makeStyles";
@@ -70,10 +70,18 @@ export function createWithStyles<Theme>(params: {
                   })()
                 : Component;
 
+        /**
+         * Get component name for wrapping
+         * @see https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging
+         */
         const name = (() => {
-            const { name } = Component_;
-
-            return typeof name === "string" ? name : undefined;
+            const { name, displayName } = Component_ as FunctionComponent;
+            if (typeof displayName === "string") {
+                return displayName;
+            }
+            if (typeof name === "string") {
+                return name;
+            }
         })();
 
         const useStyles = makeStyles<Props, any>(params)(
@@ -109,8 +117,12 @@ export function createWithStyles<Theme>(params: {
         });
 
         if (name !== undefined) {
+            const componentName = `${name}WithStyles`;
             Object.defineProperty(Out, "name", {
-                "value": `${name}WithStyles`,
+                "value": componentName,
+            });
+            Object.defineProperty(Out, "displayName", {
+                "value": componentName,
             });
         }
 


### PR DESCRIPTION
I noticed in my project some of my wrapped components were still displaying as `Anonymous` in React DevTools.

This is because they are using `.displayName` instead of `.name` for their name.
If you see [React displayName docs](https://reactjs.org/docs/react-component.html#displayname), this describes how the `displayName` property is used. This is not generally hand set but is often set for you by build tools, especially when using arrow functions.

I noticed in my testing it wasn't enough to just use the `displayName` property for getting the name, but also setting the name on the resulting component, hence the change in two places. 

This makes my DevTools much easier to read now.