### PR TITLE
update use of Component_.name to account for dollar signs in the name

### DIFF
--- a/src/withStyles.tsx
+++ b/src/withStyles.tsx
@@ -97,7 +97,7 @@ export function createWithStyles<Theme>(params: {
                 const { name } = Component_;
 
                 if (name) {
-                    return name;
+                    return name.replace(/\$/g, "usd");
                 }
             }
         })();

--- a/src/withStyles_compat.tsx
+++ b/src/withStyles_compat.tsx
@@ -84,7 +84,7 @@ export function createWithStyles<Theme>(params: {
                 const { name } = Component_;
 
                 if (name) {
-                    return name;
+                    return name.replace(/\$/g, "usd");
                 }
             }
         })();


### PR DESCRIPTION
I've run into an issue where, during our production builds, occasionally a Component name will contain a `$` at the front. Names like `$a`, or `$b` will sometimes occur. When this happens, the classname applied will then contain a `$`, which is not a legal value in CSS. The result is that the styles do not get correctly applied to the component. While this doesn't happen often, when it does occur, the consequence are pretty severe.

The change in this PR resolves that issue by replacing the `$`s in the usage of `Component_.name` with the string `usd`.  I have confirmed that this does resolve the issue in our production build in case where it was previously not working. 

I did not create a Github issue for this because I was unable to come up with a repeatable failure case that did not involve our entire code base. 